### PR TITLE
Add return-to-home flow from shop with context-aware message

### DIFF
--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import GameHeader from "@/features/header/GameHeader";
 import PixelAvatar from "@/features/avatar/PixelAvatar";
 import MenuGrid, { type MenuItem } from "@/features/menu/MenuGrid";
@@ -16,8 +16,12 @@ const menuItems = [
 ];
 
 export default function Home() {
+  const searchParams = useSearchParams();
+  const fromShop = searchParams.get("from") === "shop";
   const [activeMenuIndex, setActiveMenuIndex] = useState(0);
-  const [selectedMenuItem, setSelectedMenuItem] = useState<MenuItem>("welcome");
+  const [selectedMenuItem, setSelectedMenuItem] = useState<MenuItem>(
+    fromShop ? "returnHome" : "welcome",
+  );
   const [isTyping, setIsTyping] = useState(false);
   const [menuSelectKey, setMenuSelectKey] = useState(0);
   const router = useRouter();

--- a/src/features/menu/MenuGrid.tsx
+++ b/src/features/menu/MenuGrid.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import styles from "./MenuGrid.module.scss";
 
-export type MenuItem = "welcome" | "about" | "skills" | "works" | "contact";
+export type MenuItem = "welcome" | "about" | "skills" | "works" | "contact" | "returnHome";
 
 interface MenuGridProps {
   activeIndex: number;

--- a/src/features/message/MessageWindow.tsx
+++ b/src/features/message/MessageWindow.tsx
@@ -107,6 +107,11 @@ const messages = {
     "・くろき X のしるし（X/Twitter）\n" +
     "・みどりの知恵の書（Qiita)\n" +
     "さあ、好きな場所で 声をかけてくれ。",
+  returnHome:
+    "おかえり、旅人よ！\n" +
+    "ショップは 楽しめたかい？\n\n" +
+    "他にも なにか 見るかい？\n" +
+    "気になるものがあれば、えんりょなく 選んでくれ。",
 };
 
 export default function MessageWindow({

--- a/src/features/shop/WorksPageContent.tsx
+++ b/src/features/shop/WorksPageContent.tsx
@@ -15,7 +15,7 @@ export default function WorksPageContent() {
       <GameHeader />
       <main className={styles.main}>
         <div className={styles.backButtonRow}>
-          <Link href="/home" className={styles.backButton}>
+          <Link href="/home?from=shop" className={styles.backButton}>
             BACK TO HOME
           </Link>
         </div>


### PR DESCRIPTION
## Summary
This PR implements a context-aware return flow from the shop page back to the home menu. When users navigate back from the shop, they now see a custom welcome message acknowledging their return, rather than the standard welcome message.

## Key Changes
- **Home component**: Added `useSearchParams` hook to detect when returning from shop (`?from=shop` query parameter) and initialize the menu to show a "returnHome" message instead of the standard "welcome" message
- **Message window**: Added new "returnHome" message that greets returning users and prompts them to explore other menu options
- **Menu types**: Extended `MenuItem` type to include the new "returnHome" option
- **Shop navigation**: Updated the back button link in `WorksPageContent` to include the `?from=shop` query parameter when returning to home

## Implementation Details
- The flow uses Next.js `useSearchParams` to pass context between pages
- The initial menu item state is conditionally set based on the query parameter
- The new message maintains the existing game-like tone and style of the application

https://claude.ai/code/session_01FrCX8524MeC9pWaAjezoCo